### PR TITLE
Clear ledgers and mark pkgs as no-comp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # decompress
-a scheduled lambda that finds packages with outstanding revenue on the no-comp list and redistributes their wealth
+a scheduled lambda that finds packages that are on the no-comp list (meta.noComp) that match one of the following:
+- outstanding revenue (ads or donations)
+- the noComp flag is not on the package document
+
+with the resulting packages, it will queue Distribute Org Donations to redistribute the revenue, and it will mark all the packages with noComp:true.

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -29,33 +29,37 @@ class Mongo {
   }
 
   // 1. get all the no comp lists (one for each supported lang/reg)
-  // 2. for each list, find packages that have outstanding revenue
+  // 2. for each list, find packages that have outstanding revenue or are not marked as noComp
   // 3. combine them all into one list and return it
-  async getNoCompPackagesWithUnprocessedDonations () {
+  async getNoCompPackages () {
     const noCompLists = await this.db.collection(META_COLLECTION).find({
       name: NO_COMP
     }).toArray()
 
     const pkgsWithRevenueByLangReg = await Promise.all(noCompLists.map(async ({ language, registry, list }) => {
       return this.db.collection(PACKAGES_COLLECTION).aggregate([
-        {
+        { // matches all packages in the no-comp list `list` with the proper `language` and `registry`
+          // that either have outstanding donation revenue, outstanding ad revenue, or are not already marked as noComp
           $match: {
             name: { $in: list },
             language,
             registry,
-            $and: [
+            $or: [
               {
-                $or: [
-                  { donationRevenue: { $ne: null } },
-                  { adRevenue: { $ne: null } }
-                ]
+                donationRevenue: {
+                  $elemMatch: {
+                    processed: { $ne: true }
+                  }
+                }
               },
               {
-                $or: [
-                  { 'donationRevenue.processed': { $ne: true } },
-                  { 'adRevenue.processed': { $ne: true } }
-                ]
-              }
+                adRevenue: {
+                  $elemMatch: {
+                    processed: { $ne: true }
+                  }
+                }
+              },
+              { noComp: { $ne: true } }
             ]
           }
         },

--- a/lib/process.js
+++ b/lib/process.js
@@ -1,19 +1,26 @@
 exports.process = async ({ log, db, sqs, config, resolver }) => {
   log.info('Looking for packages on the no-comp list that have outstanding revenue')
 
-  const packages = await db.getNoCompPackagesWithUnprocessedDonations()
+  const packages = await db.getNoCompPackages()
   log.info({ packagesToProcess: packages.length })
 
   const packagesWithNoDeps = new Set((await Promise.all(
-    packages.map(async ({ name, registry, language, ...rest }) => {
-      // we don't need to check if pkgReg is falsey, because the only way packages
-      // end up in our database is through the supported registrys of registry-resolver
-      const pkgReg = resolver.getSupportedRegistry({ language, registry })
+    packages
+      .filter((p) => { // we only care that a package has no deps IF the package has revenue
+        const { donationRevenue, adRevenue } = p
+        const dr = (donationRevenue || []).reduce((sum, dono) => sum + dono.amount, 0)
+        const ar = (adRevenue || []).reduce((sum, ad) => sum + ad.amount, 0)
+        return dr + ar > 0
+      })
+      .map(async ({ name, registry, language, ...rest }) => {
+        // we don't need to check if pkgReg is falsey, because the only way packages
+        // end up in our database is through the supported registrys of registry-resolver
+        const pkgReg = resolver.getSupportedRegistry({ language, registry })
 
-      const pkgSpec = pkgReg.getSpec(pkgReg.buildLatestSpec(name))
-      const deps = await pkgReg.getDependencies(pkgSpec)
-      return { name, registry, language, ...rest, depCount: deps.length }
-    })
+        const pkgSpec = pkgReg.getSpec(pkgReg.buildLatestSpec(name))
+        const deps = await pkgReg.getDependencies(pkgSpec)
+        return { name, registry, language, ...rest, depCount: deps.length }
+      })
   )).filter(({ depCount }) => depCount === 0).map(({ _id }) => _id.toString()))
 
   const flossbankOrgId = config.getFlossbankOrgId()


### PR DESCRIPTION
Previously we queried only for packages with outstanding revenue, and of
those we queued redistribution and tagged them as noComp. This meant
that packages could exist in the DB that are noComp in `meta` but not
marked as such. We prefer to keep the package document as consistent as
possible, so this commit finds no comp packages with outstanding revenue
OR without the noComp flag. Any revenue on the returned packages is
queued for redistribution, and all the packages are marked as noComp in
the end.

As an additional optimization, I filter out revenue-less packages before
determining which packages have no deps. The no-dep check is only
important when redistributing revenue, so it can be skipped for packages
where decompress only plans on flipping the flag.